### PR TITLE
Store and enforce max battle turn limits

### DIFF
--- a/src/models/BattleMove.ts
+++ b/src/models/BattleMove.ts
@@ -151,6 +151,7 @@ export interface BattleState {
 
   // Battle properties
   turnCount: number;
+  maxTurns: number; // Turn limit before timeout
   allowFlee: boolean;
   allowItems: boolean;
   allowSwitch: boolean; // For future multi-pet battles

--- a/src/systems/BattleSystem.test.ts
+++ b/src/systems/BattleSystem.test.ts
@@ -310,18 +310,15 @@ describe('BattleSystem', () => {
   });
 
   describe('Battle End Conditions', () => {
-    beforeEach(async () => {
-      await battleSystem.initializeBattle(mockPlayerPet, mockOpponentPet, mockBattleConfig);
-    });
-
     test('should end battle when player pet is defeated', async () => {
+      await battleSystem.initializeBattle(mockPlayerPet, mockOpponentPet, mockBattleConfig);
       const battleState = battleSystem.getCurrentBattle()!;
       const playerParticipant = battleState.participants.find(p => p.team === 'player')!;
       const currentParticipant = battleSystem.getCurrentTurnParticipant()!;
-      
+
       // Reduce player health to 0
       playerParticipant.currentHealth = 0;
-      
+
       await battleSystem.processBattleAction({
         type: 'skip',
         participantId: currentParticipant.id
@@ -331,13 +328,14 @@ describe('BattleSystem', () => {
     });
 
     test('should end battle when opponent pet is defeated', async () => {
+      await battleSystem.initializeBattle(mockPlayerPet, mockOpponentPet, mockBattleConfig);
       const battleState = battleSystem.getCurrentBattle()!;
       const opponentParticipant = battleState.participants.find(p => p.team === 'enemy')!;
       const currentParticipant = battleSystem.getCurrentTurnParticipant()!;
-      
+
       // Reduce opponent health to 0
       opponentParticipant.currentHealth = 0;
-      
+
       await battleSystem.processBattleAction({
         type: 'skip',
         participantId: currentParticipant.id
@@ -347,12 +345,34 @@ describe('BattleSystem', () => {
     });
 
     test('should end battle on timeout', async () => {
+      await battleSystem.initializeBattle(mockPlayerPet, mockOpponentPet, mockBattleConfig);
       const battleState = battleSystem.getCurrentBattle()!;
       const currentParticipant = battleSystem.getCurrentTurnParticipant()!;
-      
-      // Set turn count to max
-      battleState.turnCount = 100; // Exceeds max turns from limits config
-      
+
+      // Set turn count to max from config
+      battleState.turnCount = mockBattleConfig.rules.maxTurns!;
+
+      await battleSystem.processBattleAction({
+        type: 'skip',
+        participantId: currentParticipant.id
+      });
+
+      expect(battleSystem.getCurrentBattle()).toBeNull(); // Battle ended
+    });
+
+    test('should end battle on timeout with custom max turns', async () => {
+      const customConfig = {
+        ...mockBattleConfig,
+        rules: { ...mockBattleConfig.rules, maxTurns: 10 }
+      };
+
+      await battleSystem.initializeBattle(mockPlayerPet, mockOpponentPet, customConfig);
+      const battleState = battleSystem.getCurrentBattle()!;
+      const currentParticipant = battleSystem.getCurrentTurnParticipant()!;
+
+      // Set turn count to custom max
+      battleState.turnCount = customConfig.rules.maxTurns!;
+
       await battleSystem.processBattleAction({
         type: 'skip',
         participantId: currentParticipant.id

--- a/src/systems/BattleSystem.ts
+++ b/src/systems/BattleSystem.ts
@@ -117,6 +117,7 @@ export class BattleSystem extends BaseSystem {
       currentTurn: 0,
       turnOrder,
       turnCount: 0,
+      maxTurns: config.rules.maxTurns ?? 100,
       allowFlee: config.rules.maxTurns ? config.rules.maxTurns > 0 : true,
       allowItems: !config.rules.noHealing,
       allowSwitch: false, // Not implemented yet
@@ -474,8 +475,8 @@ export class BattleSystem extends BaseSystem {
       };
     }
 
-    // Check for timeout - use a reasonable default if tuning is not available
-    const maxTurns = 100; // Default max turns
+    // Check for timeout using configured turn limit
+    const maxTurns = this.currentBattle.maxTurns ?? 100;
     if (this.currentBattle.turnCount >= maxTurns) {
       return {
         winner: 'draw',


### PR DESCRIPTION
## Summary
- Add `maxTurns` to `BattleState` and capture the configured turn limit during battle initialization
- Use stored `maxTurns` in `checkBattleEnd` to end battles by timeout instead of hard-coded value
- Expand battle timeout tests to cover custom turn limits

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa865816883258fdf5c5913a33f5c