### PR TITLE
Use BattleStatusEffect type in battle status handling

### DIFF
--- a/src/models/BattleMove.ts
+++ b/src/models/BattleMove.ts
@@ -20,6 +20,8 @@ import type {
   AIStrategy,
 } from './constants';
 
+export type { BattleStatusEffect } from './constants';
+
 /**
  * Base battle move definition
  */

--- a/src/systems/BattleSystem.ts
+++ b/src/systems/BattleSystem.ts
@@ -4,12 +4,13 @@
  */
 
 import { BaseSystem } from './BaseSystem';
-import type { 
-  BattleState, 
-  BattleParticipant, 
+import type {
+  BattleState,
+  BattleParticipant,
   BattleMove,
   BattleLogEntry,
-  BattleConfig 
+  BattleConfig,
+  BattleStatusEffect
 } from '../models/BattleMove';
 import type { Pet } from '../models/Pet';
 import { UPDATE_TYPES } from '../models/constants';
@@ -432,7 +433,10 @@ export class BattleSystem extends BaseSystem {
   /**
    * Apply status effect to a participant
    */
-  private applyStatusEffect(participant: BattleParticipant, statusEffect: { type: any, duration: number, stackable: boolean }): void {
+  private applyStatusEffect(
+    participant: BattleParticipant,
+    statusEffect: { type: BattleStatusEffect; duration: number; stackable: boolean }
+  ): void {
     // Check if effect already exists
     const existingEffect = participant.statusEffects.find(effect => effect.type === statusEffect.type);
     


### PR DESCRIPTION
## Summary
- re-export BattleStatusEffect type from battle models
- apply BattleStatusEffect enum in BattleSystem.applyStatusEffect

## Testing
- `bun run typecheck`
- `bun test`
- `bun run lint` *(fails: unstable_native_nodejs_ts_config flag not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa86af430832599d520d17a56e163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Strengthened typing for battle status effects to improve compile-time safety, with no changes to gameplay behavior.
  - Enhances developer ergonomics and reliability when working with status effects.
- Chores
  - Exposed the battle status effect type in the public API to streamline integrations and reduce type ambiguity.
  - Internal type-only updates; no impact on performance or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->