### PR TITLE
fix: Paralyze Heal cures paralysis

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -466,7 +466,7 @@ export const ITEMS_DATA: Record<string, Item> = {
     consumable: true,
     usableInBattle: true,
     effectiveness: 100,
-    curesStatus: 'poison',
+    curesStatus: 'paralysis',
   } as MedicineItem,
 
   full_heal: {

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -386,7 +386,7 @@ export type ItemObtainSource = 'shop' | 'activity' | 'event' | 'gift' | 'wild';
 export type ExtendedCurrencyType = 'coins' | 'event_tokens' | 'premium';
 
 // Cure Status Types
-export type CureStatusType = 'sickness' | 'poison' | 'all';
+export type CureStatusType = 'sickness' | 'poison' | 'paralysis' | 'all';
 
 // Food Effect Types
 export type FoodEffectType = 'energy_boost' | 'cure_sickness' | 'growth_boost';


### PR DESCRIPTION
## Summary
- correct Paralyze Heal to cure paralysis
- allow Medicine items to specify paralysis in CureStatusType

## Testing
- `bun run typecheck`
- `bun test`
- `bun run lint` *(fails: The unstable_native_nodejs_ts_config flag is not supported in older versions of Node.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ac33a3ea908325b617f3e9410ba5c5