### PR TITLE
Add stub material items for repairs and refining

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -564,6 +564,58 @@ export const ITEMS_DATA: Record<string, Item> = {
     cooldownMinutes: 10,
   } as EnergyBoosterItem,
 
+  // ========== MATERIAL ITEMS (stubs for repairs and refining) ==========
+  refined_wood: {
+    id: 'refined_wood',
+    name: 'Refined Wood',
+    description: 'Processed wood suitable for advanced crafting',
+    category: ITEM_CATEGORIES.MATERIAL,
+    sprite: 'sprites/items/refined_wood.png',
+    stackable: true,
+    maxStack: STACK_LIMITS.MATERIALS,
+    sellPrice: 8,
+    buyPrice: 16,
+    rarity: RARITY_TIERS.UNCOMMON,
+    consumable: false,
+    materialType: 'wood',
+    quality: 'fine',
+    craftingIngredient: true,
+  } as MaterialItem,
+
+  strong_string: {
+    id: 'strong_string',
+    name: 'Strong String',
+    description: 'Reinforced string used for sturdy tools',
+    category: ITEM_CATEGORIES.MATERIAL,
+    sprite: 'sprites/items/strong_string.png',
+    stackable: true,
+    maxStack: STACK_LIMITS.MATERIALS,
+    sellPrice: 6,
+    buyPrice: 12,
+    rarity: RARITY_TIERS.UNCOMMON,
+    consumable: false,
+    materialType: 'fabric',
+    quality: 'fine',
+    craftingIngredient: true,
+  } as MaterialItem,
+
+  iron_ingot: {
+    id: 'iron_ingot',
+    name: 'Iron Ingot',
+    description: 'Refined iron ready for crafting',
+    category: ITEM_CATEGORIES.MATERIAL,
+    sprite: 'sprites/items/iron_ingot.png',
+    stackable: true,
+    maxStack: STACK_LIMITS.MATERIALS,
+    sellPrice: 15,
+    buyPrice: 30,
+    rarity: RARITY_TIERS.UNCOMMON,
+    consumable: false,
+    materialType: 'ore',
+    quality: 'fine',
+    craftingIngredient: true,
+  } as MaterialItem,
+
   // ========== TOOL ITEMS ==========
   basic_fishing_rod: {
     id: 'basic_fishing_rod',


### PR DESCRIPTION
## Summary
- define `refined_wood`, `strong_string`, and `iron_ingot` material items so repair and refining references resolve

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ac33e1023483259a6f3371a92e0b02