### PR TITLE
Save state after processing offline time in GameEngine

### DIFF
--- a/src/engine/GameEngine.test.ts
+++ b/src/engine/GameEngine.test.ts
@@ -154,6 +154,12 @@ describe('GameEngine', () => {
       expect(autoStartEngine.getStatus().running).toBe(true);
       await autoStartEngine.stop();
     });
+
+    test('should save game state after processing offline time', async () => {
+      await engine.initialize();
+      const state = engine.getGameState();
+      expect(state.saveData.saveCount).toBeGreaterThan(0);
+    });
   });
 
   describe('System Management', () => {

--- a/src/engine/GameEngine.ts
+++ b/src/engine/GameEngine.ts
@@ -127,7 +127,11 @@ export class GameEngine {
       await this.loadGameState();
 
       // Process any offline time
-      await this.processOfflineTime();
+      try {
+        await this.processOfflineTime();
+      } catch (error) {
+        console.error('[GameEngine] Failed to process offline time:', error);
+      }
 
       if (this.config.autoStart) {
         await this.start();
@@ -713,6 +717,9 @@ export class GameEngine {
     if (this.config.debugMode) {
       console.log('[GameEngine] Processing offline time...');
     }
+
+    // After processing offline systems, save the game state immediately
+    await this.saveGameState();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Save updated game state immediately after processing offline time
- Handle offline time save errors during engine initialization
- Test that initialization saves state via offline processing

## Testing
- `NO_COLOR=1 bun test`

------
https://chatgpt.com/codex/tasks/task_e_68acb2b1ff9083259989ae28cb382a07