### PR TITLE
feat: track poop spawn ticks and respect sleep

### DIFF
--- a/src/systems/PetSystem.test.ts
+++ b/src/systems/PetSystem.test.ts
@@ -254,6 +254,40 @@ describe('PetSystem', () => {
     });
   });
 
+  describe('Poop spawning', () => {
+    it('should spawn poop when timer reaches zero', async () => {
+      const pet = petSystem.createPet({
+        name: 'Pooper',
+        species: 'dog',
+      });
+      gameState.pet = pet;
+
+      // Force spawn next tick
+      (petSystem as any).nextPoopTick = 1;
+
+      await petSystem.tick(1, gameState);
+
+      expect(pet.poopCount).toBe(1);
+      expect((petSystem as any).nextPoopTick).toBeGreaterThan(0);
+    });
+
+    it('should not spawn poop while pet is sleeping', async () => {
+      const pet = petSystem.createPet({
+        name: 'Sleepy',
+        species: 'dog',
+      });
+      gameState.pet = pet;
+      pet.status.primary = STATUS_TYPES.SLEEPING;
+
+      (petSystem as any).nextPoopTick = 1;
+
+      await petSystem.tick(1, gameState);
+
+      expect(pet.poopCount).toBe(0);
+      expect((petSystem as any).nextPoopTick).toBe(1);
+    });
+  });
+
   describe('Growth Stages', () => {
     it('should check growth stage eligibility', () => {
       const pet = petSystem.createPet({


### PR DESCRIPTION
## Summary
- track ticks until the next poop spawn using `nextPoopTick`
- avoid poop spawning while the pet is sleeping
- initialize and reschedule poop timer via `scheduleNextPoop`
- test poop spawn countdown and sleep handling

## Testing
- `./node_modules/.bin/eslint src/systems/PetSystem.ts src/systems/PetSystem.test.ts`
- `bun test`
- `bun run typecheck`
- `bun run format:check` *(fails: code style issues in unrelated files)*
- `npx prettier src/systems/PetSystem.ts src/systems/PetSystem.test.ts --check`

------
https://chatgpt.com/codex/tasks/task_e_68ac9d6acba08325a3c5bbfd90518004