### PR TITLE
Route timer completions through update queue

### DIFF
--- a/src/models/GameState.ts
+++ b/src/models/GameState.ts
@@ -26,6 +26,9 @@ export interface Timer {
   endTime: number;
   duration: number; // In milliseconds
   paused: boolean;
+  updateType: UpdateType;
+  payload: any;
+  recurring?: boolean;
   pausedAt?: number;
 
   // Associated data


### PR DESCRIPTION
## Summary
- Route TimeSystem timers through GameUpdates queue instead of callbacks
- Persist timer metadata for save/load and recreate expired timers on startup
- Expand TimeSystem tests for queue-based timers and persistence

## Testing
- `bun test`
- `bun run lint` *(fails: The unstable_native_nodejs_ts_config flag is not supported in older versions of Node.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2a6778c48325846c5a019b69aef8