### PR TITLE
Handle offline progress for travel, activities, and sleep

### DIFF
--- a/src/engine/GameEngine.ts
+++ b/src/engine/GameEngine.ts
@@ -749,7 +749,18 @@ export class GameEngine {
     // Process offline effects for each system
     const petSystem = this.systems.get('PetSystem') as PetSystem | undefined;
     if (petSystem) {
+      await petSystem.processOfflineSleep(offlineCalc, this.gameState);
       await petSystem.processOfflineCareDecay(offlineCalc, this.gameState);
+    }
+
+    const locationSystem = this.systems.get('LocationSystem') as LocationSystem | undefined;
+    if (locationSystem) {
+      await locationSystem.processOfflineTravel(offlineCalc, this.gameState);
+    }
+
+    const activitySystem = this.systems.get('ActivitySystem') as ActivitySystem | undefined;
+    if (activitySystem) {
+      await activitySystem.processOfflineActivities(offlineCalc, this.gameState);
     }
 
     const eggSystem = this.systems.get('EggSystem') as EggSystem | undefined;

--- a/src/systems/ActivitySystem.test.ts
+++ b/src/systems/ActivitySystem.test.ts
@@ -259,6 +259,55 @@ describe('ActivitySystem', () => {
     });
   });
 
+  describe('Offline Activity Processing', () => {
+    it('should complete activity that finished while offline', async () => {
+      const now = Date.now();
+      const result = await activitySystem.startActivity(
+        ACTIVITY_TYPES.FISHING,
+        'short',
+        gameState,
+        'lake',
+      );
+      const activityId = result.activityId!;
+      const activity = activitySystem.getActivity(activityId)!;
+
+      // Simulate timer that finished during offline
+      activity.startTime = now - 10 * 60 * 1000;
+      activity.duration = 2 * 60 * 1000;
+      const timerId = activity.timerId!;
+      gameState.world.activeTimers.push({
+        id: timerId,
+        type: 'activity',
+        startTime: activity.startTime,
+        endTime: activity.startTime + activity.duration,
+        duration: activity.duration,
+        paused: false,
+        data: { activityId },
+      });
+
+      const offlineCalc = {
+        offlineTime: 600,
+        ticksToProcess: 0,
+        careDecay: { satiety: 0, hydration: 0, happiness: 0, life: 0 },
+        poopSpawned: 0,
+        sicknessTriggered: false,
+        completedActivities: [],
+        travelCompleted: false,
+        eggsHatched: [],
+        expiredEvents: [],
+        energyRecovered: 0,
+        petDied: false,
+      };
+
+      await activitySystem.processOfflineActivities(offlineCalc, gameState);
+
+      expect(offlineCalc.completedActivities.length).toBe(1);
+      expect(offlineCalc.completedActivities[0]?.activityId).toBe(activityId);
+      expect(activitySystem.getActivity(activityId)).toBeNull();
+      expect(gameState.world.activeTimers.find((t) => t.id === timerId)).toBeUndefined();
+    });
+  });
+
   describe('cancelActivity', () => {
     it('should cancel activity and refund energy', async () => {
       const startResult = await activitySystem.startActivity(

--- a/src/systems/LocationSystem.test.ts
+++ b/src/systems/LocationSystem.test.ts
@@ -340,6 +340,52 @@ describe('LocationSystem', () => {
     });
   });
 
+  describe('Offline Travel Processing', () => {
+    it('should complete travel that finished while offline', async () => {
+      const now = Date.now();
+      gameState.world.currentLocation = {
+        currentLocationId: 'main_city',
+        currentArea: CITY_AREAS.SQUARE,
+        traveling: true,
+        inActivity: false,
+        visitedLocations: ['main_city'],
+        lastVisitTimes: { main_city: now - 1000 },
+        travelRoute: {
+          routeId: 'main_city_forest',
+          from: 'main_city',
+          to: 'forest',
+          distance: 'short',
+          duration: 3,
+          energyCost: 10,
+          progress: 0,
+          startTime: now - 10 * 60 * 1000,
+          endTime: now - 5 * 60 * 1000,
+        },
+      } as any;
+
+      const offlineCalc = {
+        offlineTime: 600,
+        ticksToProcess: 0,
+        careDecay: { satiety: 0, hydration: 0, happiness: 0, life: 0 },
+        poopSpawned: 0,
+        sicknessTriggered: false,
+        completedActivities: [],
+        travelCompleted: false,
+        eggsHatched: [],
+        expiredEvents: [],
+        energyRecovered: 0,
+        petDied: false,
+      };
+
+      await locationSystem.processOfflineTravel(offlineCalc, gameState);
+
+      expect(offlineCalc.travelCompleted).toBe(true);
+      expect(offlineCalc.newLocation).toBe('forest');
+      expect(gameState.world.currentLocation.currentLocationId).toBe('forest');
+      expect(gameState.world.currentLocation.traveling).toBe(false);
+    });
+  });
+
   describe('Reset and Shutdown', () => {
     it('should reset to default state', async () => {
       // Modify state

--- a/src/systems/LocationSystem.ts
+++ b/src/systems/LocationSystem.ts
@@ -1,6 +1,6 @@
 import { BaseSystem, type SystemInitOptions, type SystemError } from './BaseSystem';
 import type { GameUpdateWriter } from '../engine/GameUpdatesQueue';
-import type { GameState, GameUpdate } from '../models';
+import type { GameState, GameUpdate, OfflineCalculation } from '../models';
 import type {
   Location,
   CityLocation,
@@ -439,6 +439,48 @@ export class LocationSystem extends BaseSystem {
     this.currentLocationState.traveling = false;
     this.currentLocationState.travelRoute = undefined;
     this.travelTimer = null;
+  }
+
+  /**
+   * Process travel progress that occurred while offline
+   */
+  public async processOfflineTravel(
+    offlineCalc: OfflineCalculation,
+    gameState: GameState,
+  ): Promise<void> {
+    const state = gameState.world.currentLocation;
+    if (!state.traveling || !state.travelRoute || state.travelRoute.paused) {
+      this.currentLocationState = state;
+      return;
+    }
+
+    const route = state.travelRoute;
+    const now = Date.now();
+
+    if (route.endTime <= now) {
+      // Travel completed while offline
+      const destination = route.to;
+      state.traveling = false;
+      state.currentLocationId = destination;
+      state.currentArea =
+        this.locations.get(destination)?.type === LOCATION_TYPES.CITY
+          ? CITY_AREAS.SQUARE
+          : undefined;
+      if (!state.visitedLocations.includes(destination)) {
+        state.visitedLocations.push(destination);
+      }
+      state.lastVisitTimes[destination] = now;
+      state.travelRoute = undefined;
+      offlineCalc.travelCompleted = true;
+      offlineCalc.newLocation = destination;
+    } else {
+      // Update progress
+      const elapsed = now - route.startTime;
+      const total = route.endTime - route.startTime;
+      route.progress = Math.min(1, elapsed / total);
+    }
+
+    this.currentLocationState = state;
   }
 
   moveToArea(area: CityArea): boolean {


### PR DESCRIPTION
## Summary
- process offline time for travel, activities, and sleep
- add system methods to reconcile timers after offline play
- cover offline scenarios with new tests

## Testing
- `bun test src/systems/LocationSystem.test.ts src/systems/ActivitySystem.test.ts src/systems/PetSystem.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ada328a8148325bf2ddb7d1bf3aef5